### PR TITLE
Implement JSON streaming in JavalinJackson

### DIFF
--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeoutException
 import java.util.function.Supplier
+import java.util.stream.Stream
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
@@ -424,18 +425,19 @@ interface Context {
     fun json(obj: Any): Context = json(obj, obj::class.java)
 
     /**
-     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper]. The registered
-     * [io.javalin.json.JsonMapper] may write the output stream directly, or it may return a value that will
-     * be set as the context result. Also sets content type to application/json.
+     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper] and sets it as the context result.
+     * Also sets content type to application/json.
      */
-    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).apply {
-        if (!jsonMapper().handleOutputStream(outputStream(), obj, type)) {
-            result(jsonMapper().toJsonStream(obj, type))
-        }
-    }
-
+    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).result(jsonMapper().toJsonStream(obj, type))
     /** @see [jsonStream] */
     fun jsonStream(obj: Any): Context = jsonStream(obj, obj::class.java)
+
+    /**
+     * Consumes the specified stream with the configured JsonMapper, which transforms the stream's
+     * content to JSON, writing the results directly to the response's `outputStream` as the stream
+     * is consumed. This function call is synchronous, and may be wrapped in `ctx.async { }` if needed.
+     */
+    fun writeJsonStream(stream: Stream<*>) = jsonMapper().writeStream(this, stream)
 
     /** Sets context result to specified html string and sets content-type to text/html. */
     fun html(html: String): Context = contentType(ContentType.TEXT_HTML).result(html)

--- a/javalin/src/main/java/io/javalin/http/Context.kt
+++ b/javalin/src/main/java/io/javalin/http/Context.kt
@@ -424,10 +424,16 @@ interface Context {
     fun json(obj: Any): Context = json(obj, obj::class.java)
 
     /**
-     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper] and sets it as the context result.
-     * Also sets content type to application/json.
+     * Serializes object to a JSON-stream using the registered [io.javalin.json.JsonMapper]. The registered
+     * [io.javalin.json.JsonMapper] may write the output stream directly, or it may return a value that will
+     * be set as the context result. Also sets content type to application/json.
      */
-    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).result(jsonMapper().toJsonStream(obj, type))
+    fun jsonStream(obj: Any, type: Type): Context = contentType(ContentType.APPLICATION_JSON).apply {
+        if (!jsonMapper().handleOutputStream(outputStream(), obj, type)) {
+            result(jsonMapper().toJsonStream(obj, type))
+        }
+    }
+
     /** @see [jsonStream] */
     fun jsonStream(obj: Any): Context = jsonStream(obj, obj::class.java)
 

--- a/javalin/src/main/java/io/javalin/json/JsonMapper.kt
+++ b/javalin/src/main/java/io/javalin/json/JsonMapper.kt
@@ -9,6 +9,7 @@ package io.javalin.json
 import io.javalin.Javalin
 import io.javalin.http.Context
 import java.io.InputStream
+import java.io.OutputStream
 import java.lang.reflect.Type
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
@@ -27,6 +28,13 @@ interface JsonMapper {
      * an InputStream from an OutputStream.
      */
     fun toJsonStream(obj: Any, type: Type): InputStream = throw NotImplementedError("JsonMapper#toJsonStream not implemented")
+
+    /**
+     * Javalin will call this method first before calling [toJsonStream]. If this true is
+     * returned, then the responsiblity for writing all output is delegated to this function.
+     * If false is returned, then Javalin will continue with its call to [toJsonStream].
+     */
+    fun handleOutputStream(outputStream: OutputStream, obj: Any, type: Type): Boolean = false
 
     /**
      * If [.fromJsonStream] is not implemented, Javalin will use this method


### PR DESCRIPTION
This implementation checks for the object to be a `Stream<*>`. It declines to handle the conversion if it is not type `Stream`. Else it will map the stream to JSON and write it to the underlying `OutputStream`.

**No tests have been written yet.** Just trying out what these changes would look like first.